### PR TITLE
Add encoding/json interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 GO?=go
 
 DIRS:=\
+  encoding/json \
   io \
   net \
   net/http/client \

--- a/encoding/json/decoder.go
+++ b/encoding/json/decoder.go
@@ -1,0 +1,57 @@
+package json
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Decoder interface {
+	Decode(v any) error
+	Buffered() io.Reader
+	InputOffset() int64
+	More() bool
+	Token() (Token, error)
+	Nub() *json.Decoder
+}
+
+type decoderFacade struct {
+	realDecoder *json.Decoder
+}
+
+func (_ jsonFacade) NewDecoder(r io.Reader, options ...DecoderOption) Decoder {
+	dec := json.NewDecoder(r)
+
+	for _, opt := range options {
+		opt(dec)
+	}
+
+	return decoderFacade{realDecoder: dec}
+}
+
+func WrapDecoder(dec *json.Decoder) Decoder {
+	return decoderFacade{realDecoder: dec}
+}
+
+func (d decoderFacade) Decode(v any) error {
+	return d.realDecoder.Decode(v)
+}
+
+func (d decoderFacade) Buffered() io.Reader {
+	return d.realDecoder.Buffered()
+}
+
+func (d decoderFacade) InputOffset() int64 {
+	return d.realDecoder.InputOffset()
+}
+
+func (d decoderFacade) More() bool {
+	return d.realDecoder.More()
+}
+
+func (d decoderFacade) Token() (Token, error) {
+	return d.realDecoder.Token()
+}
+
+func (d decoderFacade) Nub() *json.Decoder {
+	return d.realDecoder
+}

--- a/encoding/json/encoder.go
+++ b/encoding/json/encoder.go
@@ -1,0 +1,47 @@
+package json
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Encoder interface {
+	Encode(v any) error
+	SetIndent(prefix, indent string)
+	SetEscapeHTML(on bool)
+	Nub() *json.Encoder
+}
+
+type encoderFacade struct {
+	realEncoder *json.Encoder
+}
+
+func (_ jsonFacade) NewEncoder(w io.Writer, options ...EncoderOption) Encoder {
+	enc := json.NewEncoder(w)
+
+	for _, opt := range options {
+		opt(enc)
+	}
+
+	return encoderFacade{realEncoder: enc}
+}
+
+func WrapEncoder(enc *json.Encoder) Encoder {
+	return encoderFacade{realEncoder: enc}
+}
+
+func (e encoderFacade) Encode(v any) error {
+	return e.realEncoder.Encode(v)
+}
+
+func (e encoderFacade) SetIndent(prefix, indent string) {
+	e.realEncoder.SetIndent(prefix, indent)
+}
+
+func (e encoderFacade) SetEscapeHTML(on bool) {
+	e.realEncoder.SetEscapeHTML(on)
+}
+
+func (e encoderFacade) Nub() *json.Encoder {
+	return e.realEncoder
+}

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -1,0 +1,59 @@
+// Package json provides an interface to functions and types
+// in the standard encoding/json package to facilitate mocking.
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+type JSON interface {
+	// Functions:
+	Marshal(v any) ([]byte, error)
+	MarshalIndent(v any, prefix, indent string) ([]byte, error)
+	Unmarshal(data []byte, v any) error
+	Compact(dst *bytes.Buffer, src []byte) error
+	HTMLEscape(dst *bytes.Buffer, src []byte)
+	Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error
+	Valid(data []byte) bool
+
+	// Constructors:
+	NewDecoder(r io.Reader, options ...DecoderOption) Decoder
+	NewEncoder(w io.Writer, options ...EncoderOption) Encoder
+}
+
+type jsonFacade struct {
+}
+
+func NewJSON() JSON {
+	return jsonFacade{}
+}
+
+func (_ jsonFacade) Marshal(v any) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+func (_ jsonFacade) MarshalIndent(v any, prefix, indent string) ([]byte, error) {
+	return json.MarshalIndent(v, prefix, indent)
+}
+
+func (_ jsonFacade) Unmarshal(data []byte, v any) error {
+	return json.Unmarshal(data, v)
+}
+
+func (_ jsonFacade) Compact(dst *bytes.Buffer, src []byte) error {
+	return json.Compact(dst, src)
+}
+
+func (_ jsonFacade) HTMLEscape(dst *bytes.Buffer, src []byte) {
+	json.HTMLEscape(dst, src)
+}
+
+func (_ jsonFacade) Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
+	return json.Indent(dst, src, prefix, indent)
+}
+
+func (_ jsonFacade) Valid(data []byte) bool {
+	return json.Valid(data)
+}

--- a/encoding/json/options.go
+++ b/encoding/json/options.go
@@ -1,0 +1,33 @@
+package json
+
+import (
+	"encoding/json"
+)
+
+type DecoderOption func(*json.Decoder)
+
+func WithUseNumber() DecoderOption {
+	return func(dec *json.Decoder) {
+		dec.UseNumber()
+	}
+}
+
+func WithDisallowUnknownFields() DecoderOption {
+	return func(dec *json.Decoder) {
+		dec.DisallowUnknownFields()
+	}
+}
+
+type EncoderOption func(*json.Encoder)
+
+func WithIndent(prefix, indent string) EncoderOption {
+	return func(enc *json.Encoder) {
+		enc.SetIndent(prefix, indent)
+	}
+}
+
+func WithEscapeHTML(on bool) EncoderOption {
+	return func(enc *json.Encoder) {
+		enc.SetEscapeHTML(on)
+	}
+}

--- a/encoding/json/types.go
+++ b/encoding/json/types.go
@@ -1,0 +1,23 @@
+package json
+
+import (
+	"encoding/json"
+)
+
+// Value types
+type Delim      = json.Delim
+type Number     = json.Number
+type RawMessage = json.RawMessage
+type Token      = json.Token
+
+// Interfaces for custom marshaling/unmarshaling
+type Marshaler   = json.Marshaler
+type Unmarshaler = json.Unmarshaler
+
+// Error types
+type InvalidUnmarshalError = json.InvalidUnmarshalError
+type MarshalerError        = json.MarshalerError
+type SyntaxError           = json.SyntaxError
+type UnmarshalTypeError    = json.UnmarshalTypeError
+type UnsupportedTypeError  = json.UnsupportedTypeError
+type UnsupportedValueError = json.UnsupportedValueError


### PR DESCRIPTION
## Summary
- Add mockable interfaces for Go's `encoding/json` standard library package
- Implement `JSON` interface with `Marshal`, `Unmarshal`, `Compact`, `HTMLEscape`, `Indent`, `Valid` functions
- Add `Decoder` and `Encoder` interfaces with options pattern (`WithUseNumber`, `WithDisallowUnknownFields`, `WithIndent`, `WithEscapeHTML`)
- Include type aliases for `Number`, `RawMessage`, `Delim`, `Token`, and error types

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./encoding/json/...` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.ai/code)