### PR TITLE
Add package-level functions to encoding/json

### DIFF
--- a/encoding/json/decoder.go
+++ b/encoding/json/decoder.go
@@ -19,16 +19,21 @@ type decoderFacade struct {
 }
 
 func (_ jsonFacade) NewDecoder(r io.Reader, options ...DecoderOption) Decoder {
+	return NewDecoder(r, options...)
+}
+
+func WrapDecoder(dec *json.Decoder) Decoder {
+	return decoderFacade{realDecoder: dec}
+}
+
+// NewDecoder creates a new Decoder that reads from r with optional configuration.
+func NewDecoder(r io.Reader, options ...DecoderOption) Decoder {
 	dec := json.NewDecoder(r)
 
 	for _, opt := range options {
 		opt(dec)
 	}
 
-	return decoderFacade{realDecoder: dec}
-}
-
-func WrapDecoder(dec *json.Decoder) Decoder {
 	return decoderFacade{realDecoder: dec}
 }
 

--- a/encoding/json/encoder.go
+++ b/encoding/json/encoder.go
@@ -17,16 +17,21 @@ type encoderFacade struct {
 }
 
 func (_ jsonFacade) NewEncoder(w io.Writer, options ...EncoderOption) Encoder {
+	return NewEncoder(w, options...)
+}
+
+func WrapEncoder(enc *json.Encoder) Encoder {
+	return encoderFacade{realEncoder: enc}
+}
+
+// NewEncoder creates a new Encoder that writes to w with optional configuration.
+func NewEncoder(w io.Writer, options ...EncoderOption) Encoder {
 	enc := json.NewEncoder(w)
 
 	for _, opt := range options {
 		opt(enc)
 	}
 
-	return encoderFacade{realEncoder: enc}
-}
-
-func WrapEncoder(enc *json.Encoder) Encoder {
 	return encoderFacade{realEncoder: enc}
 }
 

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -57,3 +57,18 @@ func (_ jsonFacade) Indent(dst *bytes.Buffer, src []byte, prefix, indent string)
 func (_ jsonFacade) Valid(data []byte) bool {
 	return json.Valid(data)
 }
+
+// Marshal returns the JSON encoding of v by calling encoding/json.Marshal.
+func Marshal(v any) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// MarshalIndent returns formatted JSON encoding of v by calling encoding/json.MarshalIndent.
+func MarshalIndent(v any, prefix, indent string) ([]byte, error) {
+	return json.MarshalIndent(v, prefix, indent)
+}
+
+// Unmarshal parses the JSON-encoded data and stores the result by calling encoding/json.Unmarshal.
+func Unmarshal(data []byte, v any) error {
+	return json.Unmarshal(data, v)
+}


### PR DESCRIPTION
## Summary
- Add `Marshal`, `MarshalIndent`, and `Unmarshal` package-level functions that can be called directly without requiring a `jsonFacade` instance
- Add `NewDecoder` and `NewEncoder` package-level constructors
- Refactor existing `jsonFacade` methods to call the new package-level functions (DRY principle)

## Changes
- **encoding/json/json.go**: Added 3 pass-through functions (Marshal, MarshalIndent, Unmarshal)
- **encoding/json/decoder.go**: Added NewDecoder constructor and refactored jsonFacade.NewDecoder
- **encoding/json/encoder.go**: Added NewEncoder constructor and refactored jsonFacade.NewEncoder

## Benefits
- More ergonomic API that mirrors standard library usage patterns
- Users can call `json.Marshal(v)` directly instead of `json.NewJSON().Marshal(v)`
- Full backward compatibility maintained - both approaches work

## Usage Examples

**Before (still works):**
\`\`\`go
j := json.NewJSON()
data, err := j.Marshal(myStruct)
dec := j.NewDecoder(reader)
\`\`\`

**After (new convenience API):**
\`\`\`go
data, err := json.Marshal(myStruct)
dec := json.NewDecoder(reader)
enc := json.NewEncoder(writer, json.WithIndent("", "  "))
\`\`\`

## Test plan
- [x] Build successful (`go build ./...`)
- [x] All existing tests pass (`go test ./...`)
- [x] No breaking changes to existing API

🤖 Generated with [Claude Code](https://claude.com/claude-code)