### PR TITLE
Add CLAUDE.md documentation for Claude Code

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,48 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          prompt: |
+            Review this PR for the go-interfaces library. Focus on:
+
+            **Architecture Patterns** (see CLAUDE.md):
+            - Facade pattern: proper interface definitions and facade implementations
+            - Wrapping pattern: correct use of underlying stdlib types (nub, realClient, etc.)
+            - Functional options: consistent With* option naming and application
+
+            **Go Best Practices**:
+            - Error handling
+            - Naming conventions
+            - Proper type aliasing
+            - Interface compliance
+
+            **Testing**:
+            - Unit test coverage for new interfaces
+            - Test naming conventions (*_test.go)
+            - Concurrent behavior tests where relevant
+
+            **Documentation**:
+            - Package-level comments
+            - Interface method documentation
+
+            Provide specific, actionable feedback with file:line references.
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   claude-review:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,41 @@ This repository provides interface wrappers for Go standard library packages to 
 ### Formatting
 - Format all code: `make fmt` or `go fmt ./...`
 
+## Automated Code Reviews
+
+This repository uses Claude Code to automatically review pull requests via GitHub Actions.
+
+### How It Works
+
+When you open or update a pull request, the Claude Code Review workflow (`.github/workflows/claude-review.yml`) automatically triggers and provides feedback on:
+
+- **Architecture Patterns**: Adherence to facade, wrapping, and functional options patterns
+- **Go Best Practices**: Error handling, naming conventions, type aliasing, interface compliance
+- **Testing**: Unit test coverage, test naming, concurrent behavior tests
+- **Documentation**: Package-level comments and interface method documentation
+
+Claude will post review comments directly on the PR with specific, actionable feedback including file:line references.
+
+### Setup Requirements
+
+**Repository administrators** must configure the following secret:
+
+1. Go to repository Settings → Secrets and variables → Actions
+2. Add a new secret named `ANTHROPIC_API_KEY` with your Anthropic API key
+3. The workflow will use this to authenticate with Claude's API
+
+The `GITHUB_TOKEN` is provided automatically by GitHub Actions and requires no additional setup.
+
+### Workflow Triggers
+
+The review runs automatically when:
+- A new pull request is opened
+- New commits are pushed to an existing pull request
+
+### Customizing Reviews
+
+To modify what Claude reviews, edit the `prompt` section in `.github/workflows/claude-review.yml`.
+
 ## Architecture Patterns
 
 ### Facade Pattern

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,153 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This repository provides interface wrappers for Go standard library packages to enable easy mocking in tests. Each package mirrors the structure of its corresponding standard library package while exposing mockable interfaces.
+
+## Common Commands
+
+### Testing
+- Run all tests: `make test` or `go test './...'`
+- Run tests for a specific package: `go test ./path/to/package`
+- Run a single test: `go test -run TestName ./path/to/package`
+
+### Formatting
+- Format all code: `make fmt` or `go fmt ./...`
+
+## Architecture Patterns
+
+### Facade Pattern
+
+Every package follows a consistent facade pattern with these components:
+
+1. **Interface Definition**: A primary interface (e.g., `IO`, `JSON`, `Sync`) that exposes all package functions and constructors
+2. **Facade Implementation**: A concrete type (e.g., `ioFacade`, `jsonFacade`, `syncFacade`) that implements the interface by delegating to the real standard library
+3. **Constructor**: A `New*` function that returns the facade implementation
+4. **Type Aliases**: Standard library interfaces are re-exported as type aliases (e.g., `type Reader = io.Reader`)
+
+Example structure from `io` package:
+```go
+type IO interface {
+    Copy(Writer, Reader) (int64, error)
+    // ... other functions
+}
+
+type ioFacade struct {}
+
+func NewIO() ioFacade {
+    return ioFacade{}
+}
+
+func (_ ioFacade) Copy(w Writer, r Reader) (int64, error) {
+    return io.Copy(w, r)
+}
+```
+
+### Wrapping Pattern
+
+For types that wrap standard library structs, the pattern includes:
+
+1. **Interface**: Defines the methods available on the type
+2. **Facade Type**: A struct containing a pointer to the real standard library type (named `nub`, `realClient`, `realServer`, etc.)
+3. **Constructor with Options**: A `New*` function that accepts functional options
+4. **Wrap Function**: A `Wrap*` function to wrap existing standard library instances
+5. **Delegation Methods**: Each method delegates to the underlying standard library type
+
+Example from `sync/mutex.go`:
+```go
+type Mutex interface {
+    Lock()
+    Unlock()
+    TryLock() bool
+}
+
+type mutexFacade struct {
+    realMutex *sync.Mutex
+}
+
+type MutexOption func(mut *sync.Mutex)
+
+func (_ syncFacade) NewMutex(options ...MutexOption) mutexFacade {
+    var mut sync.Mutex
+    for _, opt := range options {
+        opt(&mut)
+    }
+    return mutexFacade{realMutex: &mut}
+}
+
+func (m mutexFacade) Lock() {
+    m.realMutex.Lock()
+}
+```
+
+### Functional Options Pattern
+
+Types with configuration use functional options:
+- Options are defined as functions that modify the underlying standard library type
+- Option functions are named `With*` (e.g., `WithTimeout`, `WithTransport`)
+- Options are applied during construction before wrapping
+
+Example from `net/http/client/client.go`:
+```go
+type ClientOption func(cl *http.Client)
+
+func WithTimeout(t time.Duration) ClientOption {
+    return func(cl *http.Client) {
+        cl.Timeout = t
+    }
+}
+```
+
+### Package-Level Functions
+
+Some packages also expose direct package-level functions that bypass the facade for convenience (e.g., `encoding/json` has `Marshal`, `Unmarshal` functions that directly call `encoding/json.Marshal`, etc.).
+
+## Package Structure
+
+### Key Packages
+
+- **encoding/json**: JSON encoding/decoding with `Encoder` and `Decoder` interfaces
+- **io**: Core I/O primitives, reader/writer interfaces, and utilities
+- **io/fs**: Filesystem interfaces (`FileInfo`, `DirEntry`, `FileMode`)
+- **net**: Network dialing, listening, and connection interfaces
+- **net/http/client**: HTTP client split into separate package from server
+- **net/http/server**: HTTP server functionality
+- **os**: File operations, process management
+- **os/exec**: Command execution with `Cmd` interface
+- **os/signal**: Signal handling
+- **path** and **path/filepath**: Path manipulation
+- **sync**: Synchronization primitives (Mutex, WaitGroup, Once, Pool, Map, Cond, RWMutex)
+
+### http Package Split
+
+The `net/http` package is uniquely split into `client` and `server` subdirectories to separate client-side and server-side HTTP concerns. See `net/http/README.md`.
+
+## Testing Conventions
+
+Tests follow standard Go testing practices:
+- Test files are named `*_test.go`
+- Each package has comprehensive unit tests
+- Tests verify both interface compliance and actual functionality
+- Concurrent behavior is tested where relevant (e.g., `sync` package)
+
+## Important Implementation Details
+
+### Interface Returns
+
+When facade methods return types from the standard library that also have interface wrappers in this project, they must wrap those return values. For example:
+- `os.File` methods return wrapped `File` interfaces, not `*os.File`
+- HTTP `Client.Do()` returns wrapped `Response` interface
+- Functions that return multiple standard library types wrap each appropriately
+
+### Accessing Underlying Types
+
+Facade types provide access to the underlying standard library type when needed:
+- Method names vary: `Nub()`, `RealRequest()`, `GetUnderlyingResolver()`, etc.
+- Used when passing to code that requires the actual standard library type
+
+### Receiver Conventions
+
+- Facade methods use blank identifier receivers `(_ facadeType)` when they don't need struct state
+- Wrapper methods use named receivers when accessing the underlying type


### PR DESCRIPTION
## Summary

Adds comprehensive CLAUDE.md documentation to guide future Claude Code instances working in this repository.

## What's Included

- **Common Commands**: Testing and formatting commands from the Makefile
- **Architecture Patterns**: Detailed explanation of the three core patterns used throughout the codebase:
  - Facade Pattern (interface, facade implementation, constructor)
  - Wrapping Pattern (for types that wrap stdlib structs)
  - Functional Options Pattern (for configurable types)
- **Package Structure**: Overview of all packages with special notes about the http client/server split
- **Testing Conventions**: Standard Go testing practices
- **Implementation Details**: Critical patterns like wrapping return values and accessing underlying types

This documentation focuses on architectural patterns that require reading multiple files to understand, helping future Claude instances be productive more quickly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)