### PR TITLE
Add ProcessState interface wrapper to os package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@ go.work.sum
 .swo
 .*.swp
 .*.swo
+
+# Local settings
+.claude/*.local.json
+
+# IDEs:
+.vscode/
+.idea/

--- a/os/os_test.go
+++ b/os/os_test.go
@@ -2,6 +2,7 @@ package os
 
 import (
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -438,6 +439,9 @@ func TestOS_Getppid(t *testing.T) {
 }
 
 func TestOS_Getuid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Getuid returns -1 on Windows")
+	}
 	os := NewOS()
 
 	uid := os.Getuid()
@@ -448,6 +452,9 @@ func TestOS_Getuid(t *testing.T) {
 }
 
 func TestOS_Getgid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Getgid returns -1 on Windows")
+	}
 	os := NewOS()
 
 	gid := os.Getgid()
@@ -457,6 +464,9 @@ func TestOS_Getgid(t *testing.T) {
 }
 
 func TestOS_Geteuid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Geteuid returns -1 on Windows")
+	}
 	os := NewOS()
 
 	euid := os.Geteuid()
@@ -466,6 +476,9 @@ func TestOS_Geteuid(t *testing.T) {
 }
 
 func TestOS_Getegid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Getegid returns -1 on Windows")
+	}
 	os := NewOS()
 
 	egid := os.Getegid()

--- a/os/process.go
+++ b/os/process.go
@@ -10,7 +10,7 @@ type Process interface {
 	Kill() error
 	Release() error
 	Signal(Signal) error
-	Wait() (*ProcessState, error)
+	Wait() (ProcessState, error)
 
 	// Return the underlying process object
 	Nub() *os.Process
@@ -68,6 +68,10 @@ func (p processFacade) Signal(sig Signal) error {
 	return p.nub.Signal(sig)
 }
 
-func (p processFacade) Wait() (*ProcessState, error) {
-	return p.nub.Wait()
+func (p processFacade) Wait() (ProcessState, error) {
+	ps, err := p.nub.Wait()
+	if err != nil {
+		return nil, err
+	}
+	return WrapProcessState(ps), nil
 }

--- a/os/process_state.go
+++ b/os/process_state.go
@@ -1,0 +1,67 @@
+package os
+
+import (
+	"os"
+	"time"
+)
+
+type ProcessState interface {
+	ExitCode() int
+	Exited() bool
+	Pid() int
+	String() string
+	Success() bool
+	Sys() any
+	SysUsage() any
+	SystemTime() time.Duration
+	UserTime() time.Duration
+	Nub() *os.ProcessState
+}
+
+type processStateFacade struct {
+	nub *os.ProcessState
+}
+
+func WrapProcessState(ps *os.ProcessState) processStateFacade {
+	return processStateFacade{nub: ps}
+}
+
+func (ps processStateFacade) Nub() *os.ProcessState {
+	return ps.nub
+}
+
+func (ps processStateFacade) ExitCode() int {
+	return ps.nub.ExitCode()
+}
+
+func (ps processStateFacade) Exited() bool {
+	return ps.nub.Exited()
+}
+
+func (ps processStateFacade) Pid() int {
+	return ps.nub.Pid()
+}
+
+func (ps processStateFacade) String() string {
+	return ps.nub.String()
+}
+
+func (ps processStateFacade) Success() bool {
+	return ps.nub.Success()
+}
+
+func (ps processStateFacade) Sys() any {
+	return ps.nub.Sys()
+}
+
+func (ps processStateFacade) SysUsage() any {
+	return ps.nub.SysUsage()
+}
+
+func (ps processStateFacade) SystemTime() time.Duration {
+	return ps.nub.SystemTime()
+}
+
+func (ps processStateFacade) UserTime() time.Duration {
+	return ps.nub.UserTime()
+}

--- a/os/process_state_test.go
+++ b/os/process_state_test.go
@@ -1,0 +1,236 @@
+package os
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestWrapProcessState(t *testing.T) {
+	// Run a simple command to get a ProcessState
+	cmd := exec.Command("true")
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("Command failed: %v", err)
+	}
+
+	realPS := cmd.ProcessState
+	if realPS == nil {
+		t.Fatal("ProcessState is nil")
+	}
+
+	wrapped := WrapProcessState(realPS)
+
+	// Verify it implements the interface
+	var _ ProcessState = wrapped
+}
+
+func TestProcessState_Nub(t *testing.T) {
+	cmd := exec.Command("true")
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("Command failed: %v", err)
+	}
+
+	realPS := cmd.ProcessState
+	wrapped := WrapProcessState(realPS)
+
+	if wrapped.Nub() != realPS {
+		t.Error("Nub() did not return the original ProcessState")
+	}
+}
+
+func TestProcessState_SuccessfulCommand(t *testing.T) {
+	cmd := exec.Command("true")
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("Command failed: %v", err)
+	}
+
+	ps := WrapProcessState(cmd.ProcessState)
+
+	if ps.ExitCode() != 0 {
+		t.Errorf("ExitCode() = %d, want 0", ps.ExitCode())
+	}
+
+	if !ps.Exited() {
+		t.Error("Exited() = false, want true")
+	}
+
+	if ps.Pid() <= 0 {
+		t.Errorf("Pid() = %d, want > 0", ps.Pid())
+	}
+
+	if !ps.Success() {
+		t.Error("Success() = false, want true")
+	}
+
+	str := ps.String()
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+}
+
+func TestProcessState_FailedCommand(t *testing.T) {
+	cmd := exec.Command("false")
+	err := cmd.Run()
+	if err == nil {
+		t.Skip("'false' command did not fail as expected")
+	}
+
+	ps := WrapProcessState(cmd.ProcessState)
+
+	if ps.ExitCode() == 0 {
+		t.Error("ExitCode() = 0, want non-zero for failed command")
+	}
+
+	if !ps.Exited() {
+		t.Error("Exited() = false, want true")
+	}
+
+	if ps.Success() {
+		t.Error("Success() = true, want false for failed command")
+	}
+}
+
+func TestProcessState_Sys(t *testing.T) {
+	cmd := exec.Command("true")
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("Command failed: %v", err)
+	}
+
+	ps := WrapProcessState(cmd.ProcessState)
+
+	// Sys() returns platform-specific data, just verify it doesn't panic
+	sys := ps.Sys()
+	if sys == nil {
+		t.Log("Sys() returned nil (may be expected on some platforms)")
+	}
+}
+
+func TestProcessState_SysUsage(t *testing.T) {
+	cmd := exec.Command("true")
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("Command failed: %v", err)
+	}
+
+	ps := WrapProcessState(cmd.ProcessState)
+
+	// SysUsage() returns platform-specific data, just verify it doesn't panic
+	usage := ps.SysUsage()
+	if usage == nil {
+		t.Log("SysUsage() returned nil (may be expected on some platforms)")
+	}
+}
+
+func TestProcessState_Times(t *testing.T) {
+	cmd := exec.Command("true")
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("Command failed: %v", err)
+	}
+
+	ps := WrapProcessState(cmd.ProcessState)
+
+	// Times should be non-negative
+	userTime := ps.UserTime()
+	if userTime < 0 {
+		t.Errorf("UserTime() = %v, want >= 0", userTime)
+	}
+
+	systemTime := ps.SystemTime()
+	if systemTime < 0 {
+		t.Errorf("SystemTime() = %v, want >= 0", systemTime)
+	}
+}
+
+func TestProcessState_WithProcessWait(t *testing.T) {
+	// Test integration with Process.Wait()
+	osf := NewOS()
+
+	cmd := exec.Command("true")
+	err := cmd.Start()
+	if err != nil {
+		t.Fatalf("Command Start() failed: %v", err)
+	}
+
+	// Wrap the os.Process and call Wait()
+	proc := WrapProcess(cmd.Process)
+	ps, err := proc.Wait()
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+
+	if ps == nil {
+		t.Fatal("Wait() returned nil ProcessState")
+	}
+
+	if !ps.Success() {
+		t.Error("Wait() ProcessState.Success() = false, want true")
+	}
+
+	// Verify we can access the underlying ProcessState
+	nub := ps.Nub()
+	if nub == nil {
+		t.Error("Nub() returned nil")
+	}
+
+	// Silence unused variable warning
+	_ = osf
+}
+
+func TestProcessState_FindProcessAndWait(t *testing.T) {
+	// Start a command that we can find and wait on
+	cmd := exec.Command("sleep", "0.1")
+	err := cmd.Start()
+	if err != nil {
+		t.Fatalf("Command Start() failed: %v", err)
+	}
+
+	pid := cmd.Process.Pid
+
+	osf := NewOS()
+	proc, err := osf.FindProcess(pid)
+	if err != nil {
+		t.Fatalf("FindProcess() error = %v", err)
+	}
+
+	ps, err := proc.Wait()
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+
+	if ps.Pid() != pid {
+		t.Errorf("ProcessState.Pid() = %d, want %d", ps.Pid(), pid)
+	}
+}
+
+func TestProcessState_StartProcessAndWait(t *testing.T) {
+	osf := NewOS()
+
+	// Find the 'true' command path
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Skipf("'true' command not found: %v", err)
+	}
+
+	proc, err := osf.StartProcess(truePath, []string{"true"}, &os.ProcAttr{})
+	if err != nil {
+		t.Fatalf("StartProcess() error = %v", err)
+	}
+
+	ps, err := proc.Wait()
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+
+	if !ps.Success() {
+		t.Error("ProcessState.Success() = false, want true")
+	}
+
+	if ps.ExitCode() != 0 {
+		t.Errorf("ProcessState.ExitCode() = %d, want 0", ps.ExitCode())
+	}
+}

--- a/os/process_state_test.go
+++ b/os/process_state_test.go
@@ -220,7 +220,10 @@ func TestProcessState_StartProcessAndWait(t *testing.T) {
 		t.Fatalf("'go' command not found: %v", err)
 	}
 
-	proc, err := osf.StartProcess(goPath, []string{"go", "version"}, &os.ProcAttr{})
+	attr := &os.ProcAttr{
+		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
+	}
+	proc, err := osf.StartProcess(goPath, []string{"go", "version"}, attr)
 	if err != nil {
 		t.Fatalf("StartProcess() error = %v", err)
 	}

--- a/os/process_state_test.go
+++ b/os/process_state_test.go
@@ -3,12 +3,14 @@ package os
 import (
 	"os"
 	"os/exec"
+	"runtime"
 	"testing"
 )
 
 func TestWrapProcessState(t *testing.T) {
 	// Run a simple command to get a ProcessState
-	cmd := exec.Command("true")
+	// Use "go version" which exists on all platforms where Go tests run
+	cmd := exec.Command("go", "version")
 	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("Command failed: %v", err)
@@ -26,7 +28,7 @@ func TestWrapProcessState(t *testing.T) {
 }
 
 func TestProcessState_Nub(t *testing.T) {
-	cmd := exec.Command("true")
+	cmd := exec.Command("go", "version")
 	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("Command failed: %v", err)
@@ -41,7 +43,7 @@ func TestProcessState_Nub(t *testing.T) {
 }
 
 func TestProcessState_SuccessfulCommand(t *testing.T) {
-	cmd := exec.Command("true")
+	cmd := exec.Command("go", "version")
 	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("Command failed: %v", err)
@@ -72,10 +74,11 @@ func TestProcessState_SuccessfulCommand(t *testing.T) {
 }
 
 func TestProcessState_FailedCommand(t *testing.T) {
-	cmd := exec.Command("false")
+	// Use "go help nonexistent-command" which returns non-zero exit code cross-platform
+	cmd := exec.Command("go", "help", "nonexistent-command-that-does-not-exist")
 	err := cmd.Run()
 	if err == nil {
-		t.Skip("'false' command did not fail as expected")
+		t.Skip("Command did not fail as expected")
 	}
 
 	ps := WrapProcessState(cmd.ProcessState)
@@ -94,7 +97,7 @@ func TestProcessState_FailedCommand(t *testing.T) {
 }
 
 func TestProcessState_Sys(t *testing.T) {
-	cmd := exec.Command("true")
+	cmd := exec.Command("go", "version")
 	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("Command failed: %v", err)
@@ -110,7 +113,7 @@ func TestProcessState_Sys(t *testing.T) {
 }
 
 func TestProcessState_SysUsage(t *testing.T) {
-	cmd := exec.Command("true")
+	cmd := exec.Command("go", "version")
 	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("Command failed: %v", err)
@@ -126,7 +129,7 @@ func TestProcessState_SysUsage(t *testing.T) {
 }
 
 func TestProcessState_Times(t *testing.T) {
-	cmd := exec.Command("true")
+	cmd := exec.Command("go", "version")
 	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("Command failed: %v", err)
@@ -148,9 +151,7 @@ func TestProcessState_Times(t *testing.T) {
 
 func TestProcessState_WithProcessWait(t *testing.T) {
 	// Test integration with Process.Wait()
-	osf := NewOS()
-
-	cmd := exec.Command("true")
+	cmd := exec.Command("go", "version")
 	err := cmd.Start()
 	if err != nil {
 		t.Fatalf("Command Start() failed: %v", err)
@@ -176,14 +177,17 @@ func TestProcessState_WithProcessWait(t *testing.T) {
 	if nub == nil {
 		t.Error("Nub() returned nil")
 	}
-
-	// Silence unused variable warning
-	_ = osf
 }
 
 func TestProcessState_FindProcessAndWait(t *testing.T) {
-	// Start a command that we can find and wait on
-	cmd := exec.Command("sleep", "0.1")
+	// Use a command that takes a moment to run
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("ping", "127.0.0.1", "-n", "1")
+	} else {
+		cmd = exec.Command("sleep", "0.1")
+	}
+
 	err := cmd.Start()
 	if err != nil {
 		t.Fatalf("Command Start() failed: %v", err)
@@ -210,13 +214,13 @@ func TestProcessState_FindProcessAndWait(t *testing.T) {
 func TestProcessState_StartProcessAndWait(t *testing.T) {
 	osf := NewOS()
 
-	// Find the 'true' command path
-	truePath, err := exec.LookPath("true")
+	// Find the 'go' command path - guaranteed to exist during tests
+	goPath, err := exec.LookPath("go")
 	if err != nil {
-		t.Skipf("'true' command not found: %v", err)
+		t.Fatalf("'go' command not found: %v", err)
 	}
 
-	proc, err := osf.StartProcess(truePath, []string{"true"}, &os.ProcAttr{})
+	proc, err := osf.StartProcess(goPath, []string{"go", "version"}, &os.ProcAttr{})
 	if err != nil {
 		t.Fatalf("StartProcess() error = %v", err)
 	}

--- a/os/signal/signal_test.go
+++ b/os/signal/signal_test.go
@@ -42,14 +42,13 @@ func TestSignal_Stop(t *testing.T) {
 func TestSignal_Ignore(t *testing.T) {
 	s := NewSignal()
 
-	// Ignore SIGHUP (safe to use in tests)
-	// On Windows, only SIGINT is supported, but Ignore shouldn't panic
-	s.Ignore(syscall.SIGHUP)
+	// Ignore SIGINT (available on all platforms)
+	s.Ignore(syscall.SIGINT)
 
 	// Verify Ignored returns true
 	// Note: This may not work on all platforms
 	// Just verify it doesn't panic
-	_ = s.Ignored(syscall.SIGHUP)
+	_ = s.Ignored(syscall.SIGINT)
 }
 
 func TestSignal_Ignored(t *testing.T) {
@@ -66,10 +65,10 @@ func TestSignal_Reset(t *testing.T) {
 	s := NewSignal()
 
 	// Ignore a signal first
-	s.Ignore(syscall.SIGHUP)
+	s.Ignore(syscall.SIGINT)
 
 	// Reset should restore default behavior
-	s.Reset(syscall.SIGHUP)
+	s.Reset(syscall.SIGINT)
 
 	// Verify Reset doesn't panic
 }
@@ -165,7 +164,7 @@ func TestSignal_ResetAll(t *testing.T) {
 	s := NewSignal()
 
 	// Ignore some signals
-	s.Ignore(syscall.SIGHUP, syscall.SIGUSR1)
+	s.Ignore(syscall.SIGINT, syscall.SIGTERM)
 
 	// Reset all
 	s.Reset()

--- a/os/types.go
+++ b/os/types.go
@@ -14,6 +14,5 @@ type FSFileMode = fs.FSFileMode
 type LinkError = os.LinkError
 type PathError = os.PathError
 type ProcAttr = os.ProcAttr
-type ProcessState = os.ProcessState
 type Signal = os.Signal
 type SyscallError = os.SyscallError


### PR DESCRIPTION
## Summary

- Adds a mockable `ProcessState` interface that wraps `os.ProcessState`, following the established facade pattern
- Updates `Process.Wait()` to return the new `ProcessState` interface instead of a pointer to the type alias
- Removes the `ProcessState` type alias from `os/types.go` (replaced by the interface)
- Includes comprehensive tests for all `ProcessState` methods

## Test plan

- [x] Run `go fmt ./os/...` to verify formatting
- [x] Run `go test ./os/...` to verify all tests pass
- [x] Run `make test` to verify no regressions in other packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)